### PR TITLE
+ datadog: add global-tags

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -38,6 +38,12 @@ kamon {
     #    application.entity-name.metric-name
     application-name = "kamon"
 
+    # Tags to be appended to the existing tags (defined by the metrics). This is
+    # useful when multiple services/applications sends metrics to the same agent
+    # and it is not possible to define tags selectively in the datadog agent
+    # configuration. For example: ["type:worker", "service:mailing"]
+    global-tags = []
+
     # All time values are collected in nanoseconds,
     # to scale before sending to datadog set "time-units" to "s" or "ms" or "µs".
     # Value "n" is equivalent to omitting the setting


### PR DESCRIPTION
The idea is to allow the application to have global tags to be sent to
datadog. See reference.conf for more explanation.