### PR TITLE
Minor refactoring

### DIFF
--- a/src/main/scala/kamon/datadog/Datadog.scala
+++ b/src/main/scala/kamon/datadog/Datadog.scala
@@ -49,11 +49,11 @@ class DatadogExtension(system: ExtendedActorSystem) extends Kamon.Extension {
   val datadogMetricsListener = buildMetricsListener(tickInterval, flushInterval)
 
   val subscriptions = datadogConfig.getConfig("subscriptions")
-  subscriptions.firstLevelKeys.map { subscriptionCategory ⇒
-    subscriptions.getStringList(subscriptionCategory).asScala.foreach { pattern ⇒
-      Kamon.metrics.subscribe(subscriptionCategory, pattern, datadogMetricsListener, permanently = true)
-    }
-  }
+  for {
+    subscriptionCategory ← subscriptions.firstLevelKeys
+    pattern ← subscriptions.getStringList(subscriptionCategory).asScala
+  } Kamon.metrics.subscribe(subscriptionCategory, pattern, datadogMetricsListener, permanently = true)
+
 
   def buildMetricsListener(tickInterval: FiniteDuration, flushInterval: FiniteDuration): ActorRef = {
     assert(flushInterval >= tickInterval, "Datadog flush-interval needs to be equal or greater to the tick-interval")

--- a/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
@@ -152,7 +152,4 @@ class TestEntityRecorder(instrumentFactory: InstrumentFactory) extends GenericEn
   val counterOne = counter("counter")
 }
 
-object TestEntityRecorder extends EntityRecorderFactory[TestEntityRecorder] {
-  def category: String = "category"
-  def createRecorder(instrumentFactory: InstrumentFactory): TestEntityRecorder = new TestEntityRecorder(instrumentFactory)
-}
+object TestEntityRecorder extends EntityRecorderFactoryCompanion[TestEntityRecorder]("category", new TestEntityRecorder(_))


### PR DESCRIPTION
Use .foreach instead of .map for subscriptions initialization.
Use EntityRecorderFactoryCompanion in test.