### PR TITLE
fix agent reporter

### DIFF
--- a/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
@@ -119,7 +119,7 @@ object DatadogAgentReporter {
 
       val filteredTags = envTags ++ tags.filterKeys(filter.accept)
 
-      val stringTags: String = "#|" + filteredTags.map { case (k, v) ⇒ k + ":" + v }.mkString(",")
+      val stringTags: String = "|#" + filteredTags.map { case (k, v) ⇒ k + ":" + v }.mkString(",")
 
       StringBuilder.newBuilder
         .append(measurementData)

--- a/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogMetricSenderSpec.scala
@@ -60,8 +60,8 @@ class DatadogMetricSenderSpec extends WordSpec with Matchers with Reconfigure {
           )
         )
 
-        buffer.lst should have size (1)
-        buffer.lst should contain("test.counter" -> "0|c#|service:kamon-application,env:staging,tag1:value1")
+        buffer.lst should have size 1
+        buffer.lst should contain("test.counter" -> "0|c|#service:kamon-application,env:staging,tag1:value1")
     }
 
     "filter out blacklisted tags" in AgentReporter(new TestBuffer(), ConfigFactory.parseString(
@@ -86,8 +86,8 @@ class DatadogMetricSenderSpec extends WordSpec with Matchers with Reconfigure {
           )
         )
 
-        buffer.lst should have size (1)
-        buffer.lst should contain("test.counter" -> "0|c#|service:kamon-application,tag1:value1")
+        buffer.lst should have size 1
+        buffer.lst should contain("test.counter" -> "0|c|#service:kamon-application,tag1:value1")
     }
 
     "filter other tags" in AgentReporter(new TestBuffer(), ConfigFactory.parseString(
@@ -112,8 +112,8 @@ class DatadogMetricSenderSpec extends WordSpec with Matchers with Reconfigure {
           )
         )
 
-        buffer.lst should have size (1)
-        buffer.lst should contain("test.counter" -> "0|c#|service:kamon-application,otherTag:otherValue")
+        buffer.lst should have size 1
+        buffer.lst should contain("test.counter" -> "0|c|#service:kamon-application,otherTag:otherValue")
     }
 
   }


### PR DESCRIPTION
The PR fixes metric formatting for the Datadog agent :
```
Traceback (most recent call last):
  File "agent/dogstatsd.py", line 439, in start
    aggregator_submit(message)
  File "/home/pi/.datadog-agent/agent/aggregator.py", line 625, in submit_packets
    device_name=device_name, sample_rate=sample_rate)
  File "/home/pi/.datadog-agent/agent/aggregator.py", line 798, in submit_metric
    metric_class = self.metric_type_to_class[mtype]
KeyError: 'c#'
```
effectively changing
```
test.counter:0|c#|service:kamon-application,env:staging,tag1:value1
```
to
```
test.counter:0|c|#service:kamon-application,env:staging,tag1:value1
```