### PR TITLE
implement a legacy mapping reporter, related to #21

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -56,6 +56,40 @@ kamon {
 
     filter-config-key = "datadog-tag-filter"
 
+
+    # Metric mappings for Kamon 0.6.x compatibility
+    legacy {
+      mappings {
+
+        "akka.actor.processing-time" {
+          category = "akka-actor"
+          metric-name = "processing-time"
+          name-tag = "path"
+        }
+
+        "akka.actor.time-in-mailbox" {
+          category = "akka-actor"
+          metric-name = "time-in-mailbox"
+          name-tag = "path"
+        }
+
+        "akka.actor.mailbox-size" {
+          category = "akka-actor"
+          metric-name = "mailbox-size"
+          name-tag = "path"
+        }
+
+        "akka.actor.errors" {
+          category = "akka-actor"
+          metric-name = "errors"
+          name-tag = "path"
+        }
+      }
+    }
+
+    # Legacy setting
+    application-name = "kamon"
+
   }
   util.filters {
     datadog-tag-filter {

--- a/src/main/scala/kamon/datadog/DatadogLegacyWrapper.scala
+++ b/src/main/scala/kamon/datadog/DatadogLegacyWrapper.scala
@@ -1,0 +1,83 @@
+package kamon
+package datadog
+
+import com.typesafe.config.Config
+import kamon.datadog.DatadogLegacyWrapper.Mapping
+import kamon.metric.{ MetricDistribution, MetricValue, PeriodSnapshot }
+
+class DatadogLegacyWrapper(targetReporter: MetricReporter) extends MetricReporter {
+  private var applicationName: String = "kamon"
+  private var mappings: Map[String, Mapping] = Map.empty
+  updateConfig(Kamon.config())
+
+  override def start(): Unit = targetReporter.start()
+  override def stop(): Unit = targetReporter.stop()
+  override def reconfigure(config: Config): Unit = {
+    updateConfig(config)
+    targetReporter.reconfigure(config)
+  }
+
+  override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
+    val translatedMetrics = snapshot.metrics.copy(
+      histograms = snapshot.metrics.histograms.map(translateDistribution(_, "histogram")),
+      rangeSamplers = snapshot.metrics.rangeSamplers.map(translateDistribution(_, "min-max-counter")),
+      gauges = snapshot.metrics.gauges.map(translateValue(_, "gauge")),
+      counters = snapshot.metrics.counters.map(translateValue(_, "counter"))
+    )
+
+    targetReporter.reportPeriodSnapshot(snapshot.copy(metrics = translatedMetrics))
+  }
+
+  private def translateValue(metricValue: MetricValue, instrumentType: String): MetricValue = {
+    val mapping = mappings.getOrElse(metricValue.name, Mapping(instrumentType, metricValue.name, None))
+
+    metricValue.copy(
+      name = legacyMetricName(mapping),
+      tags = legacyTags(mapping, metricValue.tags)
+    )
+  }
+
+  private def translateDistribution(metricDistribution: MetricDistribution, instrumentType: String): MetricDistribution = {
+    val mapping = mappings.getOrElse(metricDistribution.name, Mapping(instrumentType, metricDistribution.name, None))
+
+    metricDistribution.copy(
+      name = legacyMetricName(mapping),
+      tags = legacyTags(mapping, metricDistribution.tags)
+    )
+  }
+
+  private def legacyMetricName(mapping: Mapping): String =
+    applicationName + "." + mapping.legacyCategory + "." + mapping.legacyMetricName
+
+  private def legacyTags(mapping: Mapping, tags: Map[String, String]): Map[String, String] =
+    mapping.nameTag
+      .flatMap(nameTag => tags.get(nameTag).map(name => tags.updated(mapping.legacyCategory, name)))
+      .getOrElse(tags)
+
+  private def updateConfig(config: Config): Unit = {
+    val legacyConfig = config.getConfig("kamon.datadog.legacy")
+    val mappingsConfig = legacyConfig.getConfig("mappings")
+
+    val mappingKeys = mappingsConfig.configurations.map {
+      case (key, config) =>
+        (key, Mapping(
+          legacyCategory = config.getString("category"),
+          legacyMetricName = config.getString("metric-name"),
+          nameTag = Some(config.getString("name-tag"))
+        ))
+    }
+
+    applicationName = config.getString("kamon.datadog.application-name")
+    mappings = mappingKeys
+  }
+
+}
+
+object DatadogLegacyWrapper {
+  case class Mapping(
+    legacyCategory:   String,
+    legacyMetricName: String,
+    nameTag:          Option[String]
+  )
+}
+

--- a/src/test/scala/kamon/datadog/DatadogLegacyWrapperSpec.scala
+++ b/src/test/scala/kamon/datadog/DatadogLegacyWrapperSpec.scala
@@ -1,0 +1,115 @@
+package kamon.datadog
+
+import com.typesafe.config.Config
+import kamon.{ Kamon, MetricReporter }
+import kamon.metric._
+import kamon.testkit.MetricInspection
+import org.scalatest.{ Matchers, WordSpec }
+
+class DatadogLegacyWrapperSpec extends WordSpec with Matchers with MetricInspection {
+
+  "the DatadogLegacyWrapper" should {
+    "apply known mappings to reported metrics" in {
+      report(histogram("akka.actor.processing-time", Map("path" -> "user/test/other"))) { result =>
+        val histogram = result.histograms.head
+        histogram.name shouldBe "kamon.akka-actor.processing-time"
+        histogram.tags should contain(
+          "akka-actor" -> "user/test/other"
+        )
+      }
+
+      report(counter("akka.actor.errors", Map("path" -> "user/test/other"))) { result =>
+        val counter = result.counters.head
+        counter.name shouldBe "kamon.akka-actor.errors"
+        counter.tags should contain(
+          "akka-actor" -> "user/test/other"
+        )
+      }
+
+      report(rangeSampler("akka.actor.mailbox-size", Map("path" -> "user/test/other"))) { result =>
+        val rangeSampler = result.rangeSamplers.head
+        rangeSampler.name shouldBe "kamon.akka-actor.mailbox-size"
+        rangeSampler.tags should contain(
+          "akka-actor" -> "user/test/other"
+        )
+      }
+    }
+
+    "treat all metrics without mappings as if they were single metric entities" in {
+      report(histogram("my-custom-histogram", Map("some" -> "tag"))) { result =>
+        val histogram = result.histograms.head
+        histogram.name shouldBe "kamon.histogram.my-custom-histogram"
+        histogram.tags should contain(
+          "some" -> "tag"
+        )
+      }
+
+      report(counter("my-custom-counter", Map("some" -> "tag"))) { result =>
+        val counter = result.counters.head
+        counter.name shouldBe "kamon.counter.my-custom-counter"
+        counter.tags should contain(
+          "some" -> "tag"
+        )
+      }
+
+      report(rangeSampler("my-custom-range-sampler", Map("some" -> "tag"))) { result =>
+        val rangeSampler = result.rangeSamplers.head
+        rangeSampler.name shouldBe "kamon.min-max-counter.my-custom-range-sampler"
+        rangeSampler.tags should contain(
+          "some" -> "tag"
+        )
+      }
+
+      report(gauge("my-custom-gauge", Map("some" -> "tag"))) { result =>
+        val gauge = result.gauges.head
+        gauge.name shouldBe "kamon.gauge.my-custom-gauge"
+        gauge.tags should contain(
+          "some" -> "tag"
+        )
+      }
+    }
+  }
+
+  val reporter = new FakeReporter()
+  val wrapper = new DatadogLegacyWrapper(reporter)
+
+  class FakeReporter extends MetricReporter {
+    override def start(): Unit = {}
+    override def stop(): Unit = {}
+    override def reconfigure(config: Config): Unit = {}
+
+    var metrics: MetricsSnapshot = _
+    override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
+      metrics = snapshot.metrics
+    }
+  }
+
+  def report(periodSnapshot: PeriodSnapshot)(assertions: MetricsSnapshot => Unit): Unit = {
+    wrapper.reportPeriodSnapshot(periodSnapshot)
+    assertions(reporter.metrics)
+  }
+
+  val emptyDistribution = Kamon.histogram("test").distribution()
+  val emptyPeriodSnapshot = PeriodSnapshot(Kamon.clock().instant(), Kamon.clock().instant(),
+    MetricsSnapshot(Seq.empty, Seq.empty, Seq.empty, Seq.empty))
+
+  def counter(metricName: String, tags: Map[String, String]): PeriodSnapshot = {
+    emptyPeriodSnapshot.copy(metrics = emptyPeriodSnapshot.metrics
+      .copy(counters = Seq(MetricValue(metricName, tags, MeasurementUnit.none, 1))))
+  }
+
+  def gauge(metricName: String, tags: Map[String, String]): PeriodSnapshot = {
+    emptyPeriodSnapshot.copy(metrics = emptyPeriodSnapshot.metrics
+      .copy(gauges = Seq(MetricValue(metricName, tags, MeasurementUnit.none, 1))))
+  }
+
+  def histogram(metricName: String, tags: Map[String, String]): PeriodSnapshot = {
+    emptyPeriodSnapshot.copy(metrics = emptyPeriodSnapshot.metrics
+      .copy(histograms = Seq(MetricDistribution(metricName, tags, MeasurementUnit.none, DynamicRange.Default, emptyDistribution))))
+  }
+
+  def rangeSampler(metricName: String, tags: Map[String, String]): PeriodSnapshot = {
+    emptyPeriodSnapshot.copy(metrics = emptyPeriodSnapshot.metrics
+      .copy(rangeSamplers = Seq(MetricDistribution(metricName, tags, MeasurementUnit.none, DynamicRange.Default, emptyDistribution))))
+  }
+}


### PR DESCRIPTION
This PR implements a legacy wrapper for the current reporters. The wrapper will translate the metric names and tags from the current conventions to the previous ones and should be possible to use it both with the Agent and API reporters. 

As of now it could be started like this:

```
Kamon.addReporter(new DatadogLegacyWrapper(new DatadogAgentReporter()))
```

Also, at the moment the only metrics that are actually mapped are the Akka Actor metrics, just for testing purposes. If this prototype proves viable we should include all the known metric names in the mappings config, users can add any additional.