### PR TITLE
Make the URL for the API reporter configurable

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-lazy val root: Project = project.in(file(".")).dependsOn(latestSbtUmbrella)
-lazy val latestSbtUmbrella = uri("git://github.com/kamon-io/kamon-sbt-umbrella.git")
+resolvers += Resolver.bintrayIvyRepo("kamon-io", "sbt-plugins")
 
+addSbtPlugin("io.kamon" % "kamon-sbt-umbrella" % "0.0.15")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -32,6 +32,9 @@ kamon {
       # If this is not set, metrics are sent as statsd packets over UDP to dogstatsd.
       api-key = ""
 
+      # The Datadog api endpoint to send the data to
+      api-url = "https://app.datadoghq.com/api/v1/series?api_key="
+
       connect-timeout = 5 seconds
       read-timeout = 5 seconds
       request-timeout = 5 seconds

--- a/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
@@ -59,12 +59,13 @@ class DatadogAPIReporter extends MetricReporter {
   }
 
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
+    val url = configuration.apiUrl + configuration.apiKey
     val body = RequestBody.create(jsonType, buildRequestBody(snapshot))
-    val request = new Request.Builder().url(apiUrl + configuration.apiKey).post(body).build
+    val request = new Request.Builder().url(url).post(body).build
     val response = httpClient.newCall(request).execute()
 
     if (!response.isSuccessful()) {
-      logger.error(s"Failed to POST metrics to Datadog with status code [${response.code()}], Body: [${response.body().string()}]")
+      logger.error(s"Failed to POST metrics to Datadog ${url} with status code [${response.code()}], Body: [${response.body().string()}]")
     }
 
     response.close()
@@ -135,6 +136,7 @@ class DatadogAPIReporter extends MetricReporter {
     val datadogConfig = config.getConfig("kamon.datadog")
 
     Configuration(
+      apiUrl = datadogConfig.getString("http.api-url"),
       apiKey = datadogConfig.getString("http.api-key"),
       connectTimeout = datadogConfig.getDuration("http.connect-timeout"),
       readTimeout = datadogConfig.getDuration("http.read-timeout"),
@@ -149,11 +151,10 @@ class DatadogAPIReporter extends MetricReporter {
 }
 
 private object DatadogAPIReporter {
-  val apiUrl = "https://app.datadoghq.com/api/v1/series?api_key="
   val count = "count"
   val gauge = "gauge"
 
-  case class Configuration(apiKey: String, connectTimeout: Duration, readTimeout: Duration, requestTimeout: Duration,
+  case class Configuration(apiUrl: String, apiKey: String, connectTimeout: Duration, readTimeout: Duration, requestTimeout: Duration,
                            timeUnit: MeasurementUnit, informationUnit: MeasurementUnit, extraTags: Map[String, String], tagFilter: Matcher)
 
   implicit class QuoteInterp(val sc: StringContext) extends AnyVal {


### PR DESCRIPTION
Instead of hard coding the Datadog metrics URL into the ApiReporter it is made configurable. 

For example when running tests we may want to verify metrics are gathered but report them to a dummy endpoint. 

The default remains the standard Datadog API, so standard behaviour is not affected.