### PR TITLE
Expose Datadog URI on config

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -28,6 +28,9 @@ kamon {
     #
     http {
 
+      api-url = "https://app.datadoghq.com/api/v1/series?api_key="
+
+
       # Datadog API key to use to send metrics to datadog directly over HTTPS. 
       # If this is not set, metrics are sent as statsd packets over UDP to dogstatsd.
       api-key = ""

--- a/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAPIReporter.scala
@@ -60,7 +60,7 @@ class DatadogAPIReporter extends MetricReporter {
 
   override def reportPeriodSnapshot(snapshot: PeriodSnapshot): Unit = {
     val body = RequestBody.create(jsonType, buildRequestBody(snapshot))
-    val request = new Request.Builder().url(apiUrl + configuration.apiKey).post(body).build
+    val request = new Request.Builder().url(configuration.apiUrl + configuration.apiKey).post(body).build
     val response = httpClient.newCall(request).execute()
 
     if (!response.isSuccessful()) {
@@ -135,6 +135,7 @@ class DatadogAPIReporter extends MetricReporter {
     val datadogConfig = config.getConfig("kamon.datadog")
 
     Configuration(
+      apiUrl = datadogConfig.getString("http.api-url"),
       apiKey = datadogConfig.getString("http.api-key"),
       connectTimeout = datadogConfig.getDuration("http.connect-timeout"),
       readTimeout = datadogConfig.getDuration("http.read-timeout"),
@@ -149,11 +150,10 @@ class DatadogAPIReporter extends MetricReporter {
 }
 
 private object DatadogAPIReporter {
-  val apiUrl = "https://app.datadoghq.com/api/v1/series?api_key="
   val count = "count"
   val gauge = "gauge"
 
-  case class Configuration(apiKey: String, connectTimeout: Duration, readTimeout: Duration, requestTimeout: Duration,
+  case class Configuration(apiUrl: String, apiKey: String, connectTimeout: Duration, readTimeout: Duration, requestTimeout: Duration,
                            timeUnit: MeasurementUnit, informationUnit: MeasurementUnit, extraTags: Map[String, String], tagFilter: Matcher)
 
   implicit class QuoteInterp(val sc: StringContext) extends AnyVal {

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -2,7 +2,10 @@
 
 kamon {
 
-  environment.host = test
+  environment {
+    host = test
+    tags.env = staging
+  }
 
   metric {
     tick-interval = 10 seconds


### PR DESCRIPTION
Uses configurable Datadog URI to:

- Unit testing
- Network proxying/redirecting 
- Future API location changes
- and so on...