### PR TITLE
Simplify manual creation of DatadogAgentReporter

### DIFF
--- a/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
+++ b/src/main/scala/kamon/datadog/DatadogAgentReporter.scala
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory
 
 class DatadogAgentReporterFactory extends ModuleFactory {
   override def create(settings: ModuleFactory.Settings): DatadogAgentReporter = {
-    new DatadogAgentReporter(DatadogAgentReporter.readConfiguration(Kamon.config()))
+    DatadogAgentReporter.create()
   }
 }
 // 1 arg constructor is intended for injecting config via unit tests
@@ -109,6 +109,10 @@ class DatadogAgentReporter private[datadog] (@volatile private var config: Datad
 object DatadogAgentReporter {
 
   private val logger = LoggerFactory.getLogger(classOf[DatadogAgentReporter])
+
+  def create(): DatadogAgentReporter = {
+    new DatadogAgentReporter(DatadogAgentReporter.readConfiguration(Kamon.config()))
+  }
 
   trait MeasurementFormatter {
     def formatMeasurement(measurementData: String, tags: TagSet): String


### PR DESCRIPTION
Add public create method to allow simple creation of
DatadogAgentReporter for manual registration.

There appears to be no core API for simplifying manual creation of reports. Manual creation and registration of reporters is necessary to enable filtering until kamon-io/Kamon#524 is fixed.

The prometheus reporter has a simple `create()` method on the companion object which I've adapted here.

The reason why this is still a draft is it is not clear which pattern we should standardize on. `DatadogAPIReporter` and `DataSpanReporter` are configured slightly differently. `DatadogAgentReporter`, like the prometheus reporter, ignores the settings passed to the module factory and instead loads configuration directly. Also, the `readConfiguration` method is private for the `DatadogAgentReporter`, but public for the other two reporters.

What is the preferred method for factory and manual creation of reporters? What is the preferred "public" API?

My proposal would be to standardize around the `ModuleFactory` but simplify creation with default config paths and execution contexts, it seems `ModuleFactory.Settings` is ignored in most cases anyway.